### PR TITLE
24 mask migration 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
             exit 1
           fi
 
-      - name: Lint
-        run: pixi run lint
-
       - name: Clone CaWaQS testcase fixture
         run: |
           git clone --depth 1 --filter=blob:none --sparse \

--- a/pixi.lock
+++ b/pixi.lock
@@ -295,8 +295,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: hydrologicaltwinalphaseries
-  version: 0a27
-  sha256: cf110824b7ed80a5de1ec17874736c16bb767f5c07016de049308de5eb751e6e
+  version: 0a28
+  sha256: 6832c43ac22ed1d6472993beb109eaae435dd200fafed8078220487900e0f989
   requires_dist:
   - geopandas>=1.1.2,<2
   - matplotlib>=3.10.8,<4

--- a/src/HydrologicalTwinAlphaSeries/ht/client/api_types.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/client/api_types.py
@@ -9,7 +9,7 @@ api_types in ``..api_types`` so the client surface can evolve independently
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 @dataclass(frozen=True)
@@ -135,15 +135,30 @@ class MaskWatbalResult:
 
     :param gdf: GeoDataFrame of the masked WATBAL cells, already joined to
         their mesh geometries. The caller can pass this straight to
-        ``convertGdfToVectorLayer``.
+        ``convertGdfToVectorLayer``. The geometry semantics depend on the
+        ``weighted`` flag that was passed to ``mask_watbal``:
+
+        * ``weighted=False`` (default): full cell footprints, no ``weight``
+          column — shape-identical to the pre-weighted-mask behaviour.
+        * ``weighted=True``: per-cell clipped intersection geometries
+          (``cell.intersection(polygon)``), with an additional numeric
+          ``weight`` column in ``(0, 1]``.
+
     :param layer_name: Display name for the cells layer (one per area).
     :param artefacts: On-disk artefact paths produced by the run, one CSV +
-        one .npy per requested param.
+        one .npy per requested param (plus the per-param polygon-total
+        CSVs when ``weighted=True``, plus the ``.gpkg`` when
+        ``write_geopackage=True``).
+    :param polygon_total_paths: Only populated when the call ran with
+        ``weighted=True``. Maps each requested param to the absolute path
+        of its one-column ``date, polygon_total`` CSV in ``m³/day``. Stays
+        ``None`` on the binary (unweighted) path.
     """
 
     gdf: Any
     layer_name: str
     artefacts: List[str] = field(default_factory=list)
+    polygon_total_paths: Optional[Dict[str, str]] = None
 
 
 @dataclass(frozen=True)

--- a/src/HydrologicalTwinAlphaSeries/ht/client/hydrological_twin_client.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/client/hydrological_twin_client.py
@@ -144,8 +144,10 @@ class HydrologicalTwinClient:
     def statistical_criteria(self, **kwargs) -> StatisticalCriteriaResult:
         return operations.run_statistical_criteria(self._twin, **kwargs)
 
-    def mask_watbal(self, **kwargs) -> MaskWatbalResult:
-        return operations.run_mask_watbal(self._twin, **kwargs)
+    def mask_watbal(self, *, weighted: bool = True, **kwargs) -> MaskWatbalResult:
+        # ``weighted`` is broken out from kwargs so it appears in the public
+        # signature; see :func:`operations.run_mask_watbal` for semantics.
+        return operations.run_mask_watbal(self._twin, weighted=weighted, **kwargs)
 
     def mask_hyd_boundary(self, **kwargs) -> MaskHydBoundaryResult:
         return operations.run_mask_hyd_boundary(self._twin, **kwargs)

--- a/src/HydrologicalTwinAlphaSeries/ht/client/operations.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/client/operations.py
@@ -689,8 +689,17 @@ def run_mask_watbal(
     temp_dir: str,
     area_name: str,
     write_geopackage: bool = False,
+    weighted: bool = True,
 ) -> MaskWatbalResult:
     """Mask WATBAL cells inside a polygon and persist per-param time series.
+
+    **BREAKING (from the prior behaviour)**: the per-param CSVs are now
+    written in ``m³/day`` regardless of the ``weighted`` flag. The
+    historical artefact was in ``m³/s`` (raw CaWaQS units) because the
+    earlier code bypassed ``read_watbal_converted``. Downstream consumers
+    that hard-coded ``m³/s`` must update their unit assumption; the
+    trivial migration is to multiply the new values by ``86400`` to
+    recover the old magnitude.
 
     :param twin: A configured-and-loaded :class:`HydrologicalTwin`.
     :param polygon: Shapely polygon (or MultiPolygon) defining the area.
@@ -707,8 +716,26 @@ def run_mask_watbal(
         one-row provenance table into ``<output_dir>/<area>_WATBAL_<syear>_<eyear>.gpkg``.
         Silent overwrite. The per-param CSV + ``.npy`` artefacts are
         unchanged whether the flag is true or false.
+    :param weighted: When true, opt into area-fraction weighting:
+
+        * Cells are selected by per-cell intersection area (not by
+          centroid containment), via
+          :func:`cells_in_polygon_weighted`.
+        * Per-cell time-series are multiplied by their area-fraction
+          weight (``polygon.intersection(cell).area / cell.area``).
+        * The per-param CSV carries the weighted contributions
+          (``m³/day``), not the raw per-cell values.
+        * One extra polygon-total CSV per param is written:
+          ``<output_dir>/<area_name>_<param>_polygon_total_<years>.csv``
+          (two columns: ``date, polygon_total`` in ``m³/day``).
+        * The returned ``gdf`` carries clipped intersection geometries
+          plus a ``weight`` column instead of full cell footprints.
+
+        Default ``False`` preserves today's binary behaviour (modulo the
+        ``m³/day`` unit fix described above).
     :returns: Mesh-joined cells GDF + per-param artefact paths (plus the
-        ``.gpkg`` path when ``write_geopackage`` is true).
+        ``.gpkg`` path when ``write_geopackage`` is true, plus the
+        per-param polygon-total CSV paths when ``weighted=True``).
     """
     import json  # noqa: PLC0415
     from datetime import datetime, timezone  # noqa: PLC0415
@@ -719,27 +746,19 @@ def run_mask_watbal(
 
     watbal_id = _resolve_compartment_id(twin, "WATBAL")
 
-    cells_response = twin.mask(
-        kind="polygon_cells",
-        id_compartment=watbal_id,
-        polygon=polygon,
-        polygon_crs=polygon_crs,
-    )
-
     mesh_gdf = _mesh_gdf_for(twin, watbal_id)
     id_col = _cell_id_col_name(twin, watbal_id, mesh_gdf)
-    cells_gdf = (
-        mesh_gdf.set_index(id_col)
-        .loc[list(cells_response.cell_ids)]
-        .reset_index()
-        .rename(columns={id_col: "cell_id"})
-    )
     layer_name = f"{area_name}_WATBAL_cells"
 
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(temp_dir, exist_ok=True)
-    artefacts = []
+    artefacts: list = []
     retained_responses: dict = {}
+    polygon_total_paths: dict = {}
+    polygon_total_dfs: dict = {}
+    cells_gdf = None
+    years_token = f"{syear}-{eyear}"
+
     for param in params:
         response = twin.mask(
             kind="area_values",
@@ -750,7 +769,22 @@ def run_mask_watbal(
             eyear=eyear,
             polygon=polygon,
             polygon_crs=polygon_crs,
+            target_unit="m3/j",
+            weighted=weighted,
         )
+
+        if cells_gdf is None:
+            cells_gdf = _build_cells_gdf(
+                mesh_gdf=mesh_gdf,
+                id_col=id_col,
+                response=response,
+                polygon=polygon,
+                polygon_crs=polygon_crs,
+                weighted=weighted,
+                twin=twin,
+                watbal_id=watbal_id,
+            )
+
         base = _artefact_basename("WATBAL", param, "MB", syear, eyear)
         csv_path = os.path.join(output_dir, f"{base}.csv")
         npy_path = os.path.join(temp_dir, f"{base}.npy")
@@ -765,6 +799,38 @@ def run_mask_watbal(
         artefacts.append(csv_path)
         artefacts.append(npy_path)
         retained_responses[param] = response
+
+        if weighted:
+            polygon_total = response.data.sum(axis=0)
+            total_df = pd.DataFrame(
+                {"polygon_total": polygon_total},
+                index=pd.Index(response.dates, name="date"),
+            )
+            total_path = os.path.join(
+                output_dir,
+                f"{area_name}_{param}_polygon_total_{years_token}.csv",
+            )
+            total_df.to_csv(total_path)
+            artefacts.append(total_path)
+            polygon_total_paths[param] = total_path
+            polygon_total_dfs[param] = total_df.reset_index()
+
+    if cells_gdf is None:
+        # No params requested: still build a cells GDF so the dialog can
+        # render the polygon footprint. Falls back to the centroid-in
+        # selection because there are no per-cell responses to align with.
+        cells_response = twin.mask(
+            kind="polygon_cells",
+            id_compartment=watbal_id,
+            polygon=polygon,
+            polygon_crs=polygon_crs,
+        )
+        cells_gdf = (
+            mesh_gdf.set_index(id_col)
+            .loc[list(cells_response.cell_ids)]
+            .reset_index()
+            .rename(columns={id_col: "cell_id"})
+        )
 
     if write_geopackage:
         gpkg_path = os.path.join(
@@ -781,15 +847,79 @@ def run_mask_watbal(
             "htas_ver": _htas_ver or "unknown",
             "compartment": "WATBAL",
             "params": json.dumps(list(params)),
+            "weighted": bool(weighted),
         }
         # Tier-1 privileged write — see services/SECURITY.md.
-        save_area_geopackage(gpkg_path, cells_gdf, retained_responses, provenance)
+        save_area_geopackage(
+            gpkg_path,
+            cells_gdf,
+            retained_responses,
+            provenance,
+            polygon_totals=polygon_total_dfs if weighted else None,
+            daily_values_unit_override="m3/j",
+        )
         artefacts.append(gpkg_path)
 
     return MaskWatbalResult(
         gdf=cells_gdf,
         layer_name=layer_name,
         artefacts=artefacts,
+        polygon_total_paths=polygon_total_paths if weighted else None,
+    )
+
+
+def _build_cells_gdf(
+    mesh_gdf,
+    id_col,
+    response,
+    polygon,
+    polygon_crs,
+    weighted: bool,
+    twin,
+    watbal_id,
+):
+    """Assemble the cells GeoDataFrame for ``run_mask_watbal``.
+
+    - ``weighted=False`` → full cell footprints joined from ``mesh_gdf`` on
+      the per-param response's cell_ids (or, equivalently, a polygon_cells
+      mask call); no ``weight`` column.
+    - ``weighted=True`` → clipped intersection geometries pulled directly
+      from ``response.clipped_geometries``, with a per-row ``weight``
+      column. Row order matches the per-cell response data — the dialog
+      can join cells_gdf to response.data by row position.
+    """
+    import geopandas as gpd  # noqa: PLC0415
+    import pandas as pd  # noqa: PLC0415
+
+    if weighted:
+        # Dispatcher meta carries 'cell_ids' on the target_unit path; weights
+        # and clipped_geometries are populated by the weighted branch.
+        meta_cell_ids = list((response.meta or {}).get("cell_ids", []))
+        weights = response.weights if response.weights is not None else []
+        clipped = (
+            response.clipped_geometries
+            if response.clipped_geometries is not None
+            else []
+        )
+        df = pd.DataFrame(
+            {
+                "cell_id": meta_cell_ids,
+                "weight": list(weights),
+            }
+        )
+        return gpd.GeoDataFrame(df, geometry=list(clipped), crs=mesh_gdf.crs)
+
+    cells_response = twin.mask(
+        kind="polygon_cells",
+        id_compartment=watbal_id,
+        polygon=polygon,
+        polygon_crs=polygon_crs,
+    )
+    return (
+        mesh_gdf.set_index(id_col)
+        .loc[list(cells_response.cell_ids)]
+        .reset_index()
+        .rename(columns={id_col: "cell_id"})
     )
 
 

--- a/src/HydrologicalTwinAlphaSeries/ht/client/operations.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/client/operations.py
@@ -711,11 +711,20 @@ def run_mask_watbal(
     :param output_dir: Directory for CSV artefacts.
     :param temp_dir: Directory for numpy binary artefacts.
     :param area_name: Display / filename token for the masked area.
-    :param write_geopackage: When true, additionally bundle the masked
-        cells geometry, the long-form per-(cell, date, param) values, and a
-        one-row provenance table into ``<output_dir>/<area>_WATBAL_<syear>_<eyear>.gpkg``.
-        Silent overwrite. The per-param CSV + ``.npy`` artefacts are
-        unchanged whether the flag is true or false.
+    :param write_geopackage: Selects the WATBAL output **mode** — the two
+        modes are mutually exclusive (design.md D10):
+
+        * ``True`` (GeoPackage mode): every param is still fetched (the
+          GeoPackage needs the data), but the per-param CSV, ``.npy`` and
+          per-param ``polygon_total`` CSV are NOT written. A single
+          ``<output_dir>/<area>_WATBAL_<syear>_<eyear>.gpkg`` — bundling the
+          masked cells geometry, the long-form per-``(cell, date, param)``
+          values, a one-row provenance table, and ``polygon_total_<param>``
+          tables when ``weighted=True`` — is the sole WATBAL artefact and the
+          only path in ``MaskWatbalResult.artefacts``. Silent overwrite.
+        * ``False`` (default mode): the per-param CSV + ``.npy`` (+
+          ``polygon_total`` CSVs when ``weighted=True``) are written exactly
+          as before this change, and no GeoPackage is produced.
     :param weighted: When true, opt into area-fraction weighting:
 
         * Cells are selected by per-cell intersection area (not by
@@ -785,19 +794,24 @@ def run_mask_watbal(
                 watbal_id=watbal_id,
             )
 
-        base = _artefact_basename("WATBAL", param, "MB", syear, eyear)
-        csv_path = os.path.join(output_dir, f"{base}.csv")
-        npy_path = os.path.join(temp_dir, f"{base}.npy")
-        df = pd.DataFrame(
-            response.data.T,
-            index=pd.Index(response.dates, name="date"),
-            columns=[f"cell_{i}" for i in range(response.data.shape[0])],
-        )
-        df.to_csv(csv_path)
-        # Tier-1 privileged write — see services/SECURITY.md.
-        save_area_values_npy(npy_path, response.data)
-        artefacts.append(csv_path)
-        artefacts.append(npy_path)
+        # Exclusive-mode gate (design.md D10): in GeoPackage mode the per-param
+        # CSV / .npy / polygon_total CSV are NOT written — the .gpkg is the sole
+        # WATBAL artefact. The fetch above still ran because the GeoPackage needs
+        # the data; only the disk writes below are suppressed.
+        if not write_geopackage:
+            base = _artefact_basename("WATBAL", param, "MB", syear, eyear)
+            csv_path = os.path.join(output_dir, f"{base}.csv")
+            npy_path = os.path.join(temp_dir, f"{base}.npy")
+            df = pd.DataFrame(
+                response.data.T,
+                index=pd.Index(response.dates, name="date"),
+                columns=[f"cell_{i}" for i in range(response.data.shape[0])],
+            )
+            df.to_csv(csv_path)
+            # Tier-1 privileged write — see services/SECURITY.md.
+            save_area_values_npy(npy_path, response.data)
+            artefacts.append(csv_path)
+            artefacts.append(npy_path)
         retained_responses[param] = response
 
         if weighted:
@@ -806,14 +820,18 @@ def run_mask_watbal(
                 {"polygon_total": polygon_total},
                 index=pd.Index(response.dates, name="date"),
             )
-            total_path = os.path.join(
-                output_dir,
-                f"{area_name}_{param}_polygon_total_{years_token}.csv",
-            )
-            total_df.to_csv(total_path)
-            artefacts.append(total_path)
-            polygon_total_paths[param] = total_path
+            # The polygon totals always feed the GeoPackage writer (as
+            # polygon_total_<param> tables); the standalone CSV is written only
+            # in default mode.
             polygon_total_dfs[param] = total_df.reset_index()
+            if not write_geopackage:
+                total_path = os.path.join(
+                    output_dir,
+                    f"{area_name}_{param}_polygon_total_{years_token}.csv",
+                )
+                total_df.to_csv(total_path)
+                artefacts.append(total_path)
+                polygon_total_paths[param] = total_path
 
     if cells_gdf is None:
         # No params requested: still build a cells GDF so the dialog can

--- a/src/HydrologicalTwinAlphaSeries/ht/client/operations.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/client/operations.py
@@ -17,6 +17,7 @@ from typing import Sequence, Tuple
 import numpy as np
 
 from HydrologicalTwinAlphaSeries.services.private.submodel_export import (
+    save_area_geopackage,
     save_area_values_npy,
 )
 
@@ -687,6 +688,7 @@ def run_mask_watbal(
     output_dir: str,
     temp_dir: str,
     area_name: str,
+    write_geopackage: bool = False,
 ) -> MaskWatbalResult:
     """Mask WATBAL cells inside a polygon and persist per-param time series.
 
@@ -700,9 +702,20 @@ def run_mask_watbal(
     :param output_dir: Directory for CSV artefacts.
     :param temp_dir: Directory for numpy binary artefacts.
     :param area_name: Display / filename token for the masked area.
-    :returns: Mesh-joined cells GDF + per-param artefact paths.
+    :param write_geopackage: When true, additionally bundle the masked
+        cells geometry, the long-form per-(cell, date, param) values, and a
+        one-row provenance table into ``<output_dir>/<area>_WATBAL_<syear>_<eyear>.gpkg``.
+        Silent overwrite. The per-param CSV + ``.npy`` artefacts are
+        unchanged whether the flag is true or false.
+    :returns: Mesh-joined cells GDF + per-param artefact paths (plus the
+        ``.gpkg`` path when ``write_geopackage`` is true).
     """
+    import json  # noqa: PLC0415
+    from datetime import datetime, timezone  # noqa: PLC0415
+
     import pandas as pd  # noqa: PLC0415 — local import keeps top-of-module light
+
+    from HydrologicalTwinAlphaSeries import __version__ as _htas_ver  # noqa: PLC0415
 
     watbal_id = _resolve_compartment_id(twin, "WATBAL")
 
@@ -715,12 +728,18 @@ def run_mask_watbal(
 
     mesh_gdf = _mesh_gdf_for(twin, watbal_id)
     id_col = _cell_id_col_name(twin, watbal_id, mesh_gdf)
-    cells_gdf = mesh_gdf[mesh_gdf[id_col].isin(cells_response.cell_ids)].copy()
+    cells_gdf = (
+        mesh_gdf.set_index(id_col)
+        .loc[list(cells_response.cell_ids)]
+        .reset_index()
+        .rename(columns={id_col: "cell_id"})
+    )
     layer_name = f"{area_name}_WATBAL_cells"
 
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(temp_dir, exist_ok=True)
     artefacts = []
+    retained_responses: dict = {}
     for param in params:
         response = twin.mask(
             kind="area_values",
@@ -745,6 +764,27 @@ def run_mask_watbal(
         save_area_values_npy(npy_path, response.data)
         artefacts.append(csv_path)
         artefacts.append(npy_path)
+        retained_responses[param] = response
+
+    if write_geopackage:
+        gpkg_path = os.path.join(
+            output_dir, f"{area_name}_WATBAL_{syear}_{eyear}.gpkg"
+        )
+        provenance = {
+            "source_run": getattr(twin, "out_caw_directory", "") or "",
+            "syear": syear,
+            "eyear": eyear,
+            "polygon_crs": polygon_crs or "",
+            "area_name": area_name,
+            "polygon_wkt": polygon.wkt,
+            "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "htas_ver": _htas_ver or "unknown",
+            "compartment": "WATBAL",
+            "params": json.dumps(list(params)),
+        }
+        # Tier-1 privileged write — see services/SECURITY.md.
+        save_area_geopackage(gpkg_path, cells_gdf, retained_responses, provenance)
+        artefacts.append(gpkg_path)
 
     return MaskWatbalResult(
         gdf=cells_gdf,

--- a/src/HydrologicalTwinAlphaSeries/ht/developer/api_types.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/developer/api_types.py
@@ -115,6 +115,16 @@ class FetchRequest:
 
 @dataclass
 class MaskRequest:
+    """Inputs for ``HydrologicalTwin.mask(kind=...)``.
+
+    ``weighted`` and ``target_unit`` are only consumed by
+    ``kind="area_values"`` today: when ``weighted=True``, the dispatcher
+    resolves cells via :func:`cells_in_polygon_weighted` and multiplies
+    per-cell time-series by their area-fraction weights; ``target_unit``
+    (e.g. ``"m3/j"``) routes the read through ``read_watbal_converted``
+    instead of raw ``read_values``. Other kinds ignore both fields.
+    """
+
     kind: str = "polygon_cells"
     id_compartment: Optional[int] = None
     outtype: Optional[str] = None
@@ -127,6 +137,8 @@ class MaskRequest:
     polygon: Any = None
     polygon_crs: Any = None
     cell_ids: Optional[List[int]] = None
+    weighted: bool = False
+    target_unit: Optional[str] = None
 
 
 @dataclass
@@ -216,10 +228,21 @@ class ExportRequest:
 
 @dataclass
 class ValuesResponse:
+    """Per-cell time-series response shared by ``fetch`` and ``mask`` reads.
+
+    ``weights`` and ``clipped_geometries`` are populated only on the
+    weighted polygon-mask path (``mask(kind="area_values", weighted=True)``)
+    — both fields are ``None`` on every other path so the binary-mask
+    response shape is unchanged from the parent ``add-mask-macro``
+    capability.
+    """
+
     data: np.ndarray
     dates: np.ndarray
     meta: Optional[Dict[str, Any]] = None
     csv_path: Optional[str] = None
+    weights: Optional[np.ndarray] = None
+    clipped_geometries: Optional[List[Any]] = None
 
 
 @dataclass

--- a/src/HydrologicalTwinAlphaSeries/ht/developer/dispatch.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/developer/dispatch.py
@@ -331,7 +331,7 @@ def mask(twin: "HydrologicalTwin", request: MaskRequest) -> Any:
             param=request.param,
             syear=request.syear,
             eyear=request.eyear,
-            cell_ids=np.asarray(resolved_cell_ids),
+            cell_ids=np.asarray(resolved_cell_ids, dtype=np.intp),
             id_layer=request.id_layer,
             cutsdate=request.cutsdate,
             cutedate=request.cutedate,

--- a/src/HydrologicalTwinAlphaSeries/ht/developer/dispatch.py
+++ b/src/HydrologicalTwinAlphaSeries/ht/developer/dispatch.py
@@ -54,6 +54,7 @@ from HydrologicalTwinAlphaSeries.tools.spatial_utils import (
     aq_cells_boundary_faces,
     aq_cells_on_polygon_boundary,
     cells_in_polygon,
+    cells_in_polygon_weighted,
     reaches_inflow_outflow_signs,
     verify_crs_match,
 )
@@ -76,10 +77,17 @@ from .api_types import (
     RunoffRatioResponse,
     SpatialMapResponse,
     TransformRequest,
+    ValuesResponse,
 )
 
 if TYPE_CHECKING:
     from .hydrological_twin import HydrologicalTwin  # noqa: F401
+
+
+# Units accepted when ``weighted=True`` — area-fraction weighting is only
+# physically meaningful on volumetric flux data (different cell sizes
+# contribute different volumes from the same intensity).
+_VOLUMETRIC_UNITS = frozenset({"m3/j", "m3/s"})
 
 
 def fetch(twin: "HydrologicalTwin", request: FetchRequest) -> Any:
@@ -314,6 +322,24 @@ def mask(twin: "HydrologicalTwin", request: MaskRequest) -> Any:
         assert request.param is not None
         assert request.syear is not None
         assert request.eyear is not None
+
+        if request.weighted and request.target_unit not in _VOLUMETRIC_UNITS:
+            raise ValueError(
+                "mask(kind='area_values', weighted=True) requires a volumetric "
+                f"target_unit (one of {sorted(_VOLUMETRIC_UNITS)}); got "
+                f"target_unit={request.target_unit!r}. Area-fraction weighting "
+                "only has a physical meaning on volumetric data — cells of "
+                "different sizes contribute different volumes from the same "
+                "intensity."
+            )
+        if request.weighted and request.polygon is None:
+            raise ValueError(
+                "mask(kind='area_values', weighted=True) requires 'polygon'; "
+                "weighted selection by raw 'cell_ids' is not supported."
+            )
+
+        weights: Optional[np.ndarray] = None
+        clipped_geoms: Optional[List[Any]] = None
         if request.polygon is not None:
             mesh_gdf = twin._resolve_mesh_gdf(request.id_compartment, request.id_layer)
             verify_crs_match(
@@ -322,9 +348,56 @@ def mask(twin: "HydrologicalTwin", request: MaskRequest) -> Any:
                 context="mask(kind='area_values')",
             )
             id_col = twin._resolve_cell_id_col(request.id_compartment)
-            resolved_cell_ids = cells_in_polygon(mesh_gdf, request.polygon, id_col=id_col)
+            if request.weighted:
+                triples = cells_in_polygon_weighted(
+                    mesh_gdf, request.polygon, id_col=id_col
+                )
+                resolved_cell_ids = [cid for cid, _, _ in triples]
+                weights = np.asarray([w for _, w, _ in triples], dtype=np.float64)
+                clipped_geoms = [g for _, _, g in triples]
+            else:
+                resolved_cell_ids = cells_in_polygon(
+                    mesh_gdf, request.polygon, id_col=id_col
+                )
         else:
             resolved_cell_ids = list(request.cell_ids or [])
+
+        if request.target_unit is not None:
+            full_response = twin.read_watbal_converted(
+                id_compartment=request.id_compartment,
+                outtype=request.outtype,
+                param=request.param,
+                syear=request.syear,
+                eyear=request.eyear,
+                cutsdate=request.cutsdate,
+                cutedate=request.cutedate,
+                id_layer=request.id_layer,
+                target_unit=request.target_unit,
+            )
+            cell_ids_arr = np.asarray(resolved_cell_ids, dtype=np.intp)
+            subset_data = full_response.data[cell_ids_arr]
+            if request.weighted and weights is not None:
+                subset_data = subset_data * weights[:, None]
+            meta = {
+                "id_compartment": request.id_compartment,
+                "outtype": request.outtype,
+                "param": request.param,
+                "syear": request.syear,
+                "eyear": request.eyear,
+                "id_layer": request.id_layer,
+                "n_cells": subset_data.shape[0],
+                "target_unit": request.target_unit,
+                "weighted": bool(request.weighted),
+                "cell_ids": list(resolved_cell_ids),
+            }
+            return ValuesResponse(
+                data=subset_data,
+                dates=full_response.dates,
+                meta=meta,
+                weights=weights,
+                clipped_geometries=clipped_geoms,
+            )
+
         return twin.extract_area(
             id_compartment=request.id_compartment,
             outtype=request.outtype,

--- a/src/HydrologicalTwinAlphaSeries/services/SECURITY.md
+++ b/src/HydrologicalTwinAlphaSeries/services/SECURITY.md
@@ -43,9 +43,15 @@ can be re-instantiated and run. **Must be in `services/private/`.**
 
 - *Today:* `services/private/submodel_export.py::save_area_values_npy` —
   the `.npy` write of the per-cell value array for a masked WATBAL area,
-  invoked by `ht/client/operations.py::run_mask_watbal`. This is the one
-  concrete Tier-1 artefact that exists in the repo now; it is the
+  invoked by `ht/client/operations.py::run_mask_watbal`. This is the
   precursor of the full submodel-numpy + rebuilt-config writer.
+- *Today:* `services/private/submodel_export.py::save_area_geopackage` —
+  the transportable GeoPackage bundling masked-cells geometry, long-form
+  per-(cell, date, param) values, and run provenance for a masked WATBAL
+  area; also invoked by `ht/client/operations.py::run_mask_watbal` when
+  the `write_geopackage=True` opt-in flag is set. Same Tier-1 leak
+  surface as the `.npy` writer: user-supplied geometry combined with raw
+  per-cell numeric arrays on disk.
 
 ### Tier 2 — raw per-cell time series (CSV form)
 

--- a/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
+++ b/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
@@ -21,7 +21,7 @@ Two writers live here today:
 from __future__ import annotations
 
 import sqlite3
-from typing import Mapping
+from typing import Mapping, Optional
 
 import numpy as np
 import pandas as pd
@@ -53,15 +53,21 @@ def save_area_geopackage(
     cells_gdf: GeoDataFrame,
     values_responses: Mapping[str, object],
     provenance: dict,
+    polygon_totals: Optional[Mapping[str, "pd.DataFrame"]] = None,
+    daily_values_unit_override: Optional[str] = None,
 ) -> None:
     """Persist a transportable GeoPackage for a masked area.
 
-    The produced file contains three datasets:
+    The produced file contains:
 
     - a ``cells`` vector layer with columns ``cell_id`` and ``geometry``
-      (one row per masked cell);
+      (and, when the caller's ``cells_gdf`` already has a ``weight``
+      column, that column is preserved — used by the weighted-mask path);
     - a non-spatial ``daily_values`` table in long form with columns
       ``cell_id``, ``date``, ``param``, ``value``, ``unit``;
+    - one optional non-spatial table per requested param (named
+      ``polygon_total_<param>``) when ``polygon_totals`` is supplied —
+      typically the weighted-mask path;
     - a non-spatial ``provenance`` table holding exactly one row, the
       values of which come straight from the ``provenance`` dict.
 
@@ -72,22 +78,33 @@ def save_area_geopackage(
 
     :param gpkg_path: Destination ``.gpkg`` path.
     :param cells_gdf: GeoDataFrame with a ``cell_id`` column and geometry,
-        one row per masked cell.
+        one row per masked cell. When a ``weight`` column is present it
+        is written into the ``cells`` layer alongside the geometry.
     :param values_responses: Mapping ``{param: ValuesResponse}``. Each
         ``ValuesResponse`` must expose ``data`` of shape
         ``(n_cells, n_timesteps)``, ``dates`` of length ``n_timesteps``,
         and the row order of ``data`` must match the row order of
         ``cells_gdf``.
     :param provenance: One-row provenance dict (assembled by the caller).
+    :param polygon_totals: Optional ``{param: DataFrame}`` mapping; each
+        DataFrame is the daily ``date, polygon_total`` series for that
+        param. Written as ``polygon_total_<param>`` tables. ``None`` skips
+        the polygon-total layer entirely.
+    :param daily_values_unit_override: When set, used as the ``unit``
+        column value for every row in ``daily_values`` (used by the
+        weighted-mask path where values are ``m³/day`` rather than the
+        per-param native unit declared in ``WATBAL_PARAM_UNITS``).
     """
-    cells_gdf[["cell_id", "geometry"]].to_file(
-        gpkg_path, driver="GPKG", layer="cells"
-    )
+    cell_cols = ["cell_id"]
+    if "weight" in cells_gdf.columns:
+        cell_cols.append("weight")
+    cell_cols.append("geometry")
+    cells_gdf[cell_cols].to_file(gpkg_path, driver="GPKG", layer="cells")
 
     cell_ids = list(cells_gdf["cell_id"])
     rows = []
     for param, response in values_responses.items():
-        unit = WATBAL_PARAM_UNITS.get(param, "")
+        unit = daily_values_unit_override or WATBAL_PARAM_UNITS.get(param, "")
         data = np.asarray(response.data)
         dates = np.asarray(response.dates)
         for i, cid in enumerate(cell_ids):
@@ -103,6 +120,11 @@ def save_area_geopackage(
         daily_values.to_sql(
             "daily_values", con, if_exists="replace", index=False
         )
+        if polygon_totals:
+            for param, df in polygon_totals.items():
+                df.to_sql(
+                    f"polygon_total_{param}", con, if_exists="replace", index=False
+                )
         provenance_df.to_sql(
             "provenance", con, if_exists="replace", index=False
         )

--- a/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
+++ b/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
@@ -1,16 +1,41 @@
-"""Privileged artefact writer for area-scoped submodel-grade data.
+"""Privileged artefact writers for area-scoped submodel-grade data.
 
 This module lives in ``services/private/`` because it persists the raw
 per-cell simulation array for a user-selected area — a Tier-1 leak surface
 under the project security model. See ``services/SECURITY.md`` for the
 placement rule and the threat tiers.
 
-The raw ``.npy`` written here is the precursor of the area-scoped submodel
-numpy that the advanced mask will emit; it is a rehydratable model artefact,
-not an aggregated chart, and therefore must stay behind the private boundary.
+Two writers live here today:
+
+- :func:`save_area_values_npy` — the raw ``.npy`` write of the per-cell
+  value array for one param of a masked area; the precursor of the
+  area-scoped submodel numpy.
+- :func:`save_area_geopackage` — bundles the masked cells geometry, the
+  long-form per-(cell, date, param) values table, and a one-row provenance
+  table into a single transportable GeoPackage. Same Tier-1 leak surface
+  (user-supplied geometry + raw per-cell numeric arrays on disk), hosted
+  next to ``save_area_values_npy`` so every privileged writer is reachable
+  from one auditable import path.
 """
 
+from __future__ import annotations
+
+import sqlite3
+from typing import Mapping
+
 import numpy as np
+import pandas as pd
+from geopandas import GeoDataFrame
+
+
+WATBAL_PARAM_UNITS: dict[str, str] = {
+    "rain": "mm/j",
+    "etp": "mm/j",
+    "etr": "mm/j",
+    "runoff": "mm/j",
+    "inf": "mm/j",
+    "effective_rainfall": "mm/j",
+}
 
 
 def save_area_values_npy(npy_path: str, data: np.ndarray) -> None:
@@ -21,3 +46,63 @@ def save_area_values_npy(npy_path: str, data: np.ndarray) -> None:
         by a polygon-scoped mask query.
     """
     np.save(npy_path, data)
+
+
+def save_area_geopackage(
+    gpkg_path: str,
+    cells_gdf: GeoDataFrame,
+    values_responses: Mapping[str, object],
+    provenance: dict,
+) -> None:
+    """Persist a transportable GeoPackage for a masked area.
+
+    The produced file contains three datasets:
+
+    - a ``cells`` vector layer with columns ``cell_id`` and ``geometry``
+      (one row per masked cell);
+    - a non-spatial ``daily_values`` table in long form with columns
+      ``cell_id``, ``date``, ``param``, ``value``, ``unit``;
+    - a non-spatial ``provenance`` table holding exactly one row, the
+      values of which come straight from the ``provenance`` dict.
+
+    The writer trusts that ``cells_gdf.crs`` is already correct (the caller
+    is responsible for the ``verify_crs_match`` step). The function does
+    not touch CRS. An existing file at ``gpkg_path`` is silently
+    overwritten.
+
+    :param gpkg_path: Destination ``.gpkg`` path.
+    :param cells_gdf: GeoDataFrame with a ``cell_id`` column and geometry,
+        one row per masked cell.
+    :param values_responses: Mapping ``{param: ValuesResponse}``. Each
+        ``ValuesResponse`` must expose ``data`` of shape
+        ``(n_cells, n_timesteps)``, ``dates`` of length ``n_timesteps``,
+        and the row order of ``data`` must match the row order of
+        ``cells_gdf``.
+    :param provenance: One-row provenance dict (assembled by the caller).
+    """
+    cells_gdf[["cell_id", "geometry"]].to_file(
+        gpkg_path, driver="GPKG", layer="cells"
+    )
+
+    cell_ids = list(cells_gdf["cell_id"])
+    rows = []
+    for param, response in values_responses.items():
+        unit = WATBAL_PARAM_UNITS.get(param, "")
+        data = np.asarray(response.data)
+        dates = np.asarray(response.dates)
+        for i, cid in enumerate(cell_ids):
+            for j, date in enumerate(dates):
+                rows.append((cid, date, param, float(data[i, j]), unit))
+    daily_values = pd.DataFrame(
+        rows, columns=["cell_id", "date", "param", "value", "unit"]
+    )
+
+    provenance_df = pd.DataFrame([provenance])
+
+    with sqlite3.connect(gpkg_path) as con:
+        daily_values.to_sql(
+            "daily_values", con, if_exists="replace", index=False
+        )
+        provenance_df.to_sql(
+            "provenance", con, if_exists="replace", index=False
+        )

--- a/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
+++ b/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
@@ -94,6 +94,13 @@ def save_area_geopackage(
         weighted-mask path where values are ``m³/day`` rather than the
         per-param native unit declared in ``WATBAL_PARAM_UNITS``).
     """
+    from pathlib import Path as _Path  # noqa: PLC0415
+
+    # Ensure the "silent overwrite" contract: GeoPandas.to_file with driver=
+    # "GPKG" appends layers by default, leaving stale layers from prior runs
+    # in place. Removing the file first guarantees a clean bundle.
+    _Path(gpkg_path).unlink(missing_ok=True)
+
     cell_cols = ["cell_id"]
     if "weight" in cells_gdf.columns:
         cell_cols.append("weight")

--- a/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
+++ b/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
@@ -101,17 +101,40 @@ def save_area_geopackage(
     cell_cols.append("geometry")
     cells_gdf[cell_cols].to_file(gpkg_path, driver="GPKG", layer="cells")
 
-    cell_ids = list(cells_gdf["cell_id"])
-    rows = []
+    # Vectorised long-form build (design.md D11). Equivalent to a
+    # ``param × cell × date`` triple loop emitting
+    # ``(cell_id, date, param, value, unit)`` rows in cell-major order, but
+    # without the per-row Python overhead — at 1500 cells × 25 yr × 3 params
+    # (~41 M rows) the loop was the dominant, UI-blocking cost.
+    cell_ids = np.asarray(cells_gdf["cell_id"])
+    frames = []
     for param, response in values_responses.items():
         unit = daily_values_unit_override or WATBAL_PARAM_UNITS.get(param, "")
-        data = np.asarray(response.data)
-        dates = np.asarray(response.dates)
-        for i, cid in enumerate(cell_ids):
-            for j, date in enumerate(dates):
-                rows.append((cid, date, param, float(data[i, j]), unit))
-    daily_values = pd.DataFrame(
-        rows, columns=["cell_id", "date", "param", "value", "unit"]
+        data = np.asarray(response.data, dtype=float)   # (n_cells, n_days)
+        dates = np.asarray(response.dates)         # (n_days,)
+        n_cells, n_days = data.shape
+        if n_cells != cell_ids.shape[0]:
+            raise ValueError(
+                f"cells_gdf has {cell_ids.shape[0]} cells but param {param!r} "
+                f"data has {n_cells} cells — cells_gdf and the per-param "
+                "ValuesResponse must be row-aligned."
+            )
+        frames.append(
+            pd.DataFrame(
+                {
+                    "cell_id": np.repeat(cell_ids, n_days),  # cell-major
+                    "date": np.tile(dates, n_cells),
+                    "param": param,
+                    # row-major ravel == cell-major, matching repeat/tile
+                    "value": data.ravel(),
+                    "unit": unit,
+                }
+            )
+        )
+    daily_values = (
+        pd.concat(frames, ignore_index=True)
+        if frames
+        else pd.DataFrame(columns=["cell_id", "date", "param", "value", "unit"])
     )
 
     provenance_df = pd.DataFrame([provenance])

--- a/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
+++ b/src/HydrologicalTwinAlphaSeries/services/private/submodel_export.py
@@ -27,7 +27,6 @@ import numpy as np
 import pandas as pd
 from geopandas import GeoDataFrame
 
-
 WATBAL_PARAM_UNITS: dict[str, str] = {
     "rain": "mm/j",
     "etp": "mm/j",

--- a/src/HydrologicalTwinAlphaSeries/services/public/vec_operator.py
+++ b/src/HydrologicalTwinAlphaSeries/services/public/vec_operator.py
@@ -1,4 +1,5 @@
 
+import warnings
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
@@ -348,8 +349,48 @@ class Extractor:
         if cell_ids is None:
             raise ValueError("Either 'cell_ids' or 'spatial_operator' must be provided")
 
-        # Extract data for the specified cells
-        return data[cell_ids, :]
+        cell_ids_arr = np.asarray(cell_ids)
+        if cell_ids_arr.size and not np.issubdtype(cell_ids_arr.dtype, np.integer):
+            if np.issubdtype(cell_ids_arr.dtype, np.floating):
+                if not np.all(np.equal(np.mod(cell_ids_arr, 1), 0)):
+                    raise ValueError(
+                        "cell_ids contains non-integer float values; cannot index into data."
+                    )
+            cell_ids_arr = cell_ids_arr.astype(np.intp)
+
+        # Cell-id values are used as 0-based row positions into `data`.
+        # Validate that contract and surface a clear message when it breaks.
+        n_rows = data.shape[0]
+        if cell_ids_arr.size:
+            lo, hi = int(cell_ids_arr.min()), int(cell_ids_arr.max())
+            if lo < 0 or hi >= n_rows:
+                likely_one_based = lo == 1 and hi == n_rows
+                hint = (
+                    " This looks like a 1-based id range (min=1, max=n_rows) — "
+                    "if the mesh id column is 1-based, callers must subtract 1 "
+                    "before passing ids to apply_spatial_mask."
+                    if likely_one_based
+                    else ""
+                )
+                raise IndexError(
+                    f"cell_ids out of range for data with {n_rows} rows: "
+                    f"min={lo}, max={hi}. Cell-id values must be 0-based row "
+                    f"positions into the values array.{hint}"
+                )
+            # In-range but suspicious: smallest id is >= 1 and largest id is exactly
+            # n_rows - 1 + 1's offset would have tripped above, so we can only catch
+            # the "ids never reference row 0 even though they could have" hint.
+            if lo >= 1 and cell_ids_arr.size >= n_rows:
+                warnings.warn(
+                    "cell_ids cover {n} positions but never reference row 0 — "
+                    "this can indicate a 1-based id convention being silently "
+                    "off-by-one against the 0-based values array.".format(
+                        n=cell_ids_arr.size
+                    ),
+                    stacklevel=2,
+                )
+
+        return data[cell_ids_arr, :]
 
     def _get_cell_ids_from_operator(
         self,

--- a/src/HydrologicalTwinAlphaSeries/tools/spatial_utils.py
+++ b/src/HydrologicalTwinAlphaSeries/tools/spatial_utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import geopandas as gpd
 import numpy as np
@@ -285,6 +285,9 @@ def cells_in_polygon(
     polygon's bounding box, keeping the helper fast on large meshes
     (tested up to ~14 000 cells).
 
+    For area-fraction weighted selection (per-cell weights + clipped
+    intersection geometries), see :func:`cells_in_polygon_weighted`.
+
     :param mesh_gdf: GeoDataFrame of mesh cells (polygon geometries)
     :param polygon: shapely ``Polygon`` or ``MultiPolygon`` defining the mask
     :param id_col: Column name (or integer position) to read cell ids from.
@@ -306,6 +309,83 @@ def cells_in_polygon(
     sorted_positions = sorted(matched_positions)
     col_name = _resolve_id_col(mesh_gdf, id_col)
     return [mesh_gdf.iloc[p][col_name] for p in sorted_positions]
+
+
+# Hardcoded floor (dimensionless area ratio): cells with weight below this
+# are considered to share only a boundary edge / vertex with the polygon
+# and are dropped as floating-point grit. A meaningful contribution of
+# 0.01% is weight = 1e-4, four orders of magnitude above this floor.
+_WEIGHTED_MIN_WEIGHT = 1e-6
+
+
+def cells_in_polygon_weighted(
+    mesh_gdf: gpd.GeoDataFrame,
+    polygon: Any,
+    id_col: Union[str, int],
+) -> List[Tuple[Any, float, Any]]:
+    """Return mesh cells with their area-fraction weight inside ``polygon``.
+
+    For each cell whose *footprint* survives the polygon STRtree prefilter
+    (i.e. any part of the cell overlaps the polygon — not a centroid test),
+    computes ``intersection = polygon.intersection(cell)`` once and derives
+    ``weight = clip(intersection.area / cell.area, 0.0, 1.0)``. Cells with
+    ``weight < 1e-6`` (floor that absorbs floating-point drift from
+    shared-edge / vertex-only touches) are dropped.
+
+    ``MultiPolygon`` inputs are handled by shapely's intersection directly,
+    so a cell straddling two components is counted once with the summed
+    fraction. Interior rings (holes) are treated as outside, matching
+    :func:`cells_in_polygon`.
+
+    A Shapely STRtree on cell footprints prefilters candidates by the
+    polygon's bounding box (unlike ``cells_in_polygon``, which indexes
+    centroids because it is a centroid test). Intersection geometry is
+    computed only on the small subset of survivors, so performance stays
+    comparable to the binary helper on large meshes.
+
+    The ``1e-6`` floor is intentionally not exposed as a parameter — it
+    represents pure floating-point noise, not a user-tunable knob.
+
+    :param mesh_gdf: GeoDataFrame of mesh cells (polygon geometries)
+    :param polygon: shapely ``Polygon`` or ``MultiPolygon`` defining the mask
+    :param id_col: Column name (or integer position) to read cell ids from.
+    :return: List of ``(cell_id, weight, clipped_geometry)`` triples in
+        mesh-row order. ``weight`` is in ``(0, 1]`` after the floor cut and
+        clip; ``clipped_geometry`` is ``polygon.intersection(cell)``.
+    """
+    if mesh_gdf.empty:
+        return []
+
+    geometries = list(mesh_gdf.geometry.values)
+    # Prefilter on the cell *footprints*, not their centroids: a border cell
+    # is in scope if any part of it overlaps the polygon, even when its
+    # centroid falls outside. (The binary `cells_in_polygon` indexes
+    # centroids on purpose — it *is* a centroid test; the weighted helper
+    # must not, or it silently collapses back to centroid containment.)
+    tree = shapely.STRtree(geometries)
+
+    candidate_positions: set = set()
+    for component in _polygon_components(polygon):
+        for pos in tree.query(component, predicate="intersects"):
+            candidate_positions.add(int(pos))
+
+    col_name = _resolve_id_col(mesh_gdf, id_col)
+    results: List[Tuple[Any, float, Any]] = []
+    for pos in sorted(candidate_positions):
+        cell_geom = geometries[pos]
+        cell_area = cell_geom.area
+        if cell_area <= 0.0:
+            continue
+        intersection = polygon.intersection(cell_geom)
+        if intersection.is_empty:
+            continue
+        raw_weight = intersection.area / cell_area
+        weight = float(min(1.0, max(0.0, raw_weight)))
+        if weight < _WEIGHTED_MIN_WEIGHT:
+            continue
+        results.append((mesh_gdf.iloc[pos][col_name], weight, intersection))
+
+    return results
 
 
 def _reach_endpoints(geom: Any) -> tuple:

--- a/tests/unit/test_mask_macro.py
+++ b/tests/unit/test_mask_macro.py
@@ -239,6 +239,144 @@ def test_mask_area_values_with_polygon_crs_mismatch_raises(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# kind="area_values" — target_unit + weighted=True extensions
+# ---------------------------------------------------------------------------
+
+
+def _make_full_mesh_values_response(n_cells: int, n_timesteps: int = 4) -> ValuesResponse:
+    """Row i carries the constant value (i+1) so callers can read off which cell each row maps to."""
+    data = np.ones((n_cells, n_timesteps)) * np.arange(1, n_cells + 1).reshape(-1, 1)
+    dates = np.arange("2010-08-01", "2010-08-05", dtype="datetime64[D]")
+    return ValuesResponse(data=data, dates=dates)
+
+
+def test_mask_area_values_target_unit_routes_through_read_watbal_converted(monkeypatch):
+    """target_unit set: dispatcher must call read_watbal_converted (not extract_area)."""
+    mesh = _grid_mesh()  # 9 cells, ids 0..8
+    twin = _twin_with_mock_compartment(monkeypatch, mesh)
+    captured = {}
+
+    def fake_read_watbal_converted(**kwargs):
+        captured.update(kwargs)
+        return _make_full_mesh_values_response(n_cells=9)
+
+    monkeypatch.setattr(twin, "read_watbal_converted", fake_read_watbal_converted)
+
+    def fail_extract_area(**_kw):
+        raise AssertionError("extract_area must not be called when target_unit is set")
+
+    monkeypatch.setattr(twin, "extract_area", fail_extract_area)
+
+    polygon = box(0.1, 0.1, 1.9, 1.9)  # cells 0, 1, 3, 4
+
+    response = twin.mask(**_area_values_kwargs(polygon=polygon, target_unit="m3/j"))
+
+    assert captured["target_unit"] == "m3/j"
+    assert isinstance(response, ValuesResponse)
+    assert response.data.shape == (4, 4)
+    # Unweighted path subsets cells 0,1,3,4 → row values 1,2,4,5.
+    np.testing.assert_array_equal(response.data[:, 0], [1.0, 2.0, 4.0, 5.0])
+    # Unweighted: response.weights and clipped_geometries stay None.
+    assert response.weights is None
+    assert response.clipped_geometries is None
+    assert response.meta["target_unit"] == "m3/j"
+    assert response.meta["weighted"] is False
+
+
+def test_mask_area_values_weighted_returns_weights_and_clipped_geometries(monkeypatch):
+    """weighted=True: response carries per-cell weights + clipped geometries."""
+    mesh = _grid_mesh()  # 9 cells
+    twin = _twin_with_mock_compartment(monkeypatch, mesh)
+    monkeypatch.setattr(
+        twin,
+        "read_watbal_converted",
+        lambda **_kw: _make_full_mesh_values_response(n_cells=9),
+    )
+    # 2x2 covering cells 0,1,3,4 fully → all weights = 1.0.
+    polygon = box(0.0, 0.0, 2.0, 2.0)
+
+    response = twin.mask(
+        **_area_values_kwargs(polygon=polygon, weighted=True, target_unit="m3/j")
+    )
+
+    assert isinstance(response, ValuesResponse)
+    assert response.weights is not None
+    assert response.clipped_geometries is not None
+    assert len(response.weights) == response.data.shape[0]
+    assert len(response.clipped_geometries) == response.data.shape[0]
+    # Fully-inside cells: weight = 1.0 ⇒ data unchanged.
+    np.testing.assert_allclose(response.weights, 1.0)
+    # data row order matches mesh-order cells 0, 1, 3, 4 → values 1, 2, 4, 5.
+    np.testing.assert_array_equal(response.data[:, 0], [1.0, 2.0, 4.0, 5.0])
+    assert response.meta["weighted"] is True
+
+
+def test_mask_area_values_weighted_partial_overlap_scales_data(monkeypatch):
+    """weighted=True: data row of a 60%-inside cell equals base * 0.6."""
+    mesh = _grid_mesh(nx=2, ny=1)  # cells 0 and 1
+    twin = _twin_with_mock_compartment(monkeypatch, mesh)
+    monkeypatch.setattr(
+        twin,
+        "read_watbal_converted",
+        lambda **_kw: _make_full_mesh_values_response(n_cells=2),
+    )
+    # Cell 0 entirely inside (weight=1.0), cell 1 60% inside.
+    polygon = box(0.0, 0.0, 1.6, 1.0)
+
+    response = twin.mask(
+        **_area_values_kwargs(polygon=polygon, weighted=True, target_unit="m3/j")
+    )
+
+    np.testing.assert_allclose(response.weights, [1.0, 0.6])
+    np.testing.assert_allclose(response.data[:, 0], [1.0, 2.0 * 0.6])
+
+
+def test_mask_area_values_unweighted_leaves_response_fields_none(monkeypatch):
+    """weighted=False (default): weights + clipped_geometries are None even on the polygon path."""
+    mesh = _grid_mesh()
+    twin = _twin_with_mock_compartment(monkeypatch, mesh)
+    expected = ValuesResponse(data=np.zeros((4, 5)), dates=np.arange(5))
+    monkeypatch.setattr(twin, "extract_area", lambda **_kw: expected)
+
+    polygon = box(0.1, 0.1, 1.9, 1.9)
+    response = twin.mask(**_area_values_kwargs(polygon=polygon))
+
+    assert response.weights is None
+    assert response.clipped_geometries is None
+
+
+def test_mask_area_values_weighted_without_target_unit_raises(monkeypatch):
+    mesh = _grid_mesh()
+    twin = _twin_with_mock_compartment(monkeypatch, mesh)
+    polygon = box(0.0, 0.0, 2.0, 2.0)
+
+    with pytest.raises(ValueError, match="volumetric"):
+        twin.mask(**_area_values_kwargs(polygon=polygon, weighted=True))
+
+
+def test_mask_area_values_weighted_with_non_volumetric_unit_raises(monkeypatch):
+    mesh = _grid_mesh()
+    twin = _twin_with_mock_compartment(monkeypatch, mesh)
+    polygon = box(0.0, 0.0, 2.0, 2.0)
+
+    with pytest.raises(ValueError, match="volumetric"):
+        twin.mask(
+            **_area_values_kwargs(polygon=polygon, weighted=True, target_unit="mm/j")
+        )
+
+
+def test_mask_area_values_weighted_without_polygon_raises(monkeypatch):
+    twin = _twin_in_loaded_state()
+
+    with pytest.raises(ValueError, match="weighted=True"):
+        twin.mask(
+            **_area_values_kwargs(
+                cell_ids=[1, 2, 3], weighted=True, target_unit="m3/j"
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
 # S5 — kind="boundary_hyd" + HydBoundaryResponse
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_operations_mask_watbal_gpkg.py
+++ b/tests/unit/test_operations_mask_watbal_gpkg.py
@@ -81,16 +81,19 @@ def test_run_mask_watbal_writes_gpkg_when_flag_true(tmp_path: Path, monkeypatch)
         temp_dir=str(temp_dir),
         area_name="basin_A",
         write_geopackage=True,
+        weighted=False,
     )
 
     gpkg_path = output_dir / "basin_A_WATBAL_2000_2000.gpkg"
     assert gpkg_path.exists()
-    assert str(gpkg_path) in result.artefacts
 
-    csv_paths = [p for p in result.artefacts if p.endswith(".csv")]
-    npy_paths = [p for p in result.artefacts if p.endswith(".npy")]
-    assert len(csv_paths) == 2
-    assert len(npy_paths) == 2
+    # Exclusive mode (design.md D10): the .gpkg is the SOLE WATBAL artefact —
+    # no per-param CSV / .npy in the result or on disk.
+    assert result.artefacts == [str(gpkg_path)]
+    assert not any(p.endswith(".csv") for p in result.artefacts)
+    assert not any(p.endswith(".npy") for p in result.artefacts)
+    assert list(output_dir.glob("*.csv")) == []
+    assert list(temp_dir.glob("*.npy")) == []
 
     with sqlite3.connect(str(gpkg_path)) as con:
         daily = pd.read_sql_query("SELECT * FROM daily_values", con)
@@ -118,6 +121,7 @@ def test_run_mask_watbal_no_gpkg_when_flag_false_or_omitted(tmp_path: Path, monk
         output_dir=str(output_dir),
         temp_dir=str(temp_dir),
         area_name="basin_A",
+        weighted=False,
     )
 
     gpkgs = list(output_dir.glob("*.gpkg"))
@@ -130,16 +134,18 @@ def test_run_mask_watbal_no_gpkg_when_flag_false_or_omitted(tmp_path: Path, monk
     assert len(npy_paths) == 2
 
 
-def test_run_mask_watbal_csv_npy_parity_with_and_without_gpkg(tmp_path: Path, monkeypatch):
+def test_run_mask_watbal_modes_are_mutually_exclusive(tmp_path: Path, monkeypatch):
+    """Exclusive mode (design.md D10): default-mode writes CSV+.npy and no
+    .gpkg; GeoPackage-mode writes only the .gpkg and no CSV/.npy. No run
+    produces both."""
     twin, polygon, mesh_gdf = _fake_twin_and_polygon()
     _patch_twin_helpers(monkeypatch, mesh_gdf)
 
-    run_a = tmp_path / "A"
-    run_b = tmp_path / "B"
-    (run_a / "OUTPUTS").mkdir(parents=True)
-    (run_a / "TEMP").mkdir(parents=True)
-    (run_b / "OUTPUTS").mkdir(parents=True)
-    (run_b / "TEMP").mkdir(parents=True)
+    run_a = tmp_path / "A"   # default mode
+    run_b = tmp_path / "B"   # GeoPackage mode
+    for run in (run_a, run_b):
+        (run / "OUTPUTS").mkdir(parents=True)
+        (run / "TEMP").mkdir(parents=True)
 
     operations.run_mask_watbal(
         twin,
@@ -152,6 +158,7 @@ def test_run_mask_watbal_csv_npy_parity_with_and_without_gpkg(tmp_path: Path, mo
         temp_dir=str(run_a / "TEMP"),
         area_name="basin_A",
         write_geopackage=False,
+        weighted=False,
     )
 
     operations.run_mask_watbal(
@@ -165,15 +172,23 @@ def test_run_mask_watbal_csv_npy_parity_with_and_without_gpkg(tmp_path: Path, mo
         temp_dir=str(run_b / "TEMP"),
         area_name="basin_A",
         write_geopackage=True,
+        weighted=False,
     )
 
     files_a = _collect_files(run_a / "OUTPUTS", run_a / "TEMP")
-    files_b = {
-        name: data
-        for name, data in _collect_files(run_b / "OUTPUTS", run_b / "TEMP").items()
-        if not name.endswith(".gpkg")
-    }
-    assert files_a == files_b
+    files_b = _collect_files(run_b / "OUTPUTS", run_b / "TEMP")
+
+    # Default mode: CSV + .npy, no .gpkg.
+    assert any(n.endswith(".csv") for n in files_a)
+    assert any(n.endswith(".npy") for n in files_a)
+    assert not any(n.endswith(".gpkg") for n in files_a)
+
+    # GeoPackage mode: exactly the .gpkg, nothing else.
+    assert [n for n in files_b if n.endswith(".gpkg")] == [
+        "basin_A_WATBAL_2000_2000.gpkg"
+    ]
+    assert not any(n.endswith(".csv") for n in files_b)
+    assert not any(n.endswith(".npy") for n in files_b)
 
 
 # ---------------------------------------------------------------------------
@@ -285,6 +300,7 @@ def test_run_mask_watbal_unweighted_has_no_polygon_total_paths(
         output_dir=str(output_dir),
         temp_dir=str(temp_dir),
         area_name="basin_A",
+        weighted=False,
     )
 
     assert result.polygon_total_paths is None
@@ -331,6 +347,7 @@ def test_run_mask_watbal_unweighted_gdf_has_no_weight_column(
         output_dir=str(tmp_path / "OUTPUTS"),
         temp_dir=str(tmp_path / "TEMP"),
         area_name="basin_A",
+        weighted=False,
     )
 
     assert "weight" not in result.gdf.columns
@@ -359,7 +376,11 @@ def test_run_mask_watbal_weighted_gpkg_bundles_weighted_artefacts(
 
     gpkg_path = output_dir / "basin_A_WATBAL_2000_2000.gpkg"
     assert gpkg_path.exists()
-    assert str(gpkg_path) in result.artefacts
+    # Exclusive mode: the .gpkg is the sole artefact even on the weighted path —
+    # the polygon totals live inside it (polygon_total_rain), not as a CSV.
+    assert result.artefacts == [str(gpkg_path)]
+    assert result.polygon_total_paths in (None, {})
+    assert list(output_dir.glob("*.csv")) == []
 
     with sqlite3.connect(str(gpkg_path)) as con:
         cells = pd.read_sql_query("SELECT * FROM cells", con)

--- a/tests/unit/test_operations_mask_watbal_gpkg.py
+++ b/tests/unit/test_operations_mask_watbal_gpkg.py
@@ -1,0 +1,178 @@
+"""Orchestration tests for ``run_mask_watbal`` with/without GeoPackage export."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import Polygon, box
+
+from HydrologicalTwinAlphaSeries.ht import (
+    CellSelectionResponse,
+    ValuesResponse,
+)
+from HydrologicalTwinAlphaSeries.ht.client import operations
+
+
+def _fake_twin_and_polygon():
+    cell_ids = [10, 20, 30]
+    mesh_gdf = gpd.GeoDataFrame(
+        {"id_cell": cell_ids},
+        geometry=[box(i, 0, i + 1, 1) for i in range(3)],
+        crs="EPSG:2154",
+    )
+    dates = np.array(["2000-01-01", "2000-01-02", "2000-01-03", "2000-01-04"])
+
+    def fake_mask(kind, **kwargs):
+        if kind == "polygon_cells":
+            return CellSelectionResponse(
+                cell_ids=list(cell_ids),
+                meta={"id_compartment": 1, "kind": "polygon_cells"},
+            )
+        if kind == "area_values":
+            param = kwargs["param"]
+            data = np.full((len(cell_ids), len(dates)), float(hash(param) % 1000))
+            return ValuesResponse(data=data, dates=dates)
+        raise ValueError(f"unexpected mask kind: {kind!r}")
+
+    twin = SimpleNamespace(
+        mask=fake_mask,
+        out_caw_directory="/tmp/fake_out_caw",
+    )
+    polygon = Polygon([(0, 0), (3, 0), (3, 1), (0, 1)])
+    return twin, polygon, mesh_gdf
+
+
+def _patch_twin_helpers(monkeypatch, mesh_gdf):
+    monkeypatch.setattr(operations, "_resolve_compartment_id", lambda twin, name: 1)
+    monkeypatch.setattr(operations, "_mesh_gdf_for", lambda twin, cid, id_layer=0: mesh_gdf)
+    monkeypatch.setattr(
+        operations, "_cell_id_col_name", lambda twin, cid, gdf: "id_cell"
+    )
+
+
+def _collect_files(*dirs: Path) -> dict[str, bytes]:
+    out: dict[str, bytes] = {}
+    for d in dirs:
+        for p in sorted(d.iterdir()):
+            if p.is_file():
+                out[p.name] = p.read_bytes()
+    return out
+
+
+def test_run_mask_watbal_writes_gpkg_when_flag_true(tmp_path: Path, monkeypatch):
+    twin, polygon, mesh_gdf = _fake_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+    output_dir = tmp_path / "OUTPUTS"
+    temp_dir = tmp_path / "TEMP"
+
+    result = operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain", "runoff"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(output_dir),
+        temp_dir=str(temp_dir),
+        area_name="basin_A",
+        write_geopackage=True,
+    )
+
+    gpkg_path = output_dir / "basin_A_WATBAL_2000_2000.gpkg"
+    assert gpkg_path.exists()
+    assert str(gpkg_path) in result.artefacts
+
+    csv_paths = [p for p in result.artefacts if p.endswith(".csv")]
+    npy_paths = [p for p in result.artefacts if p.endswith(".npy")]
+    assert len(csv_paths) == 2
+    assert len(npy_paths) == 2
+
+    with sqlite3.connect(str(gpkg_path)) as con:
+        daily = pd.read_sql_query("SELECT * FROM daily_values", con)
+        prov = pd.read_sql_query("SELECT * FROM provenance", con)
+    assert len(daily) == 3 * 4 * 2
+    assert set(daily["param"].unique()) == {"rain", "runoff"}
+    assert prov.iloc[0]["compartment"] == "WATBAL"
+    assert prov.iloc[0]["area_name"] == "basin_A"
+    assert prov.iloc[0]["source_run"] == "/tmp/fake_out_caw"
+
+
+def test_run_mask_watbal_no_gpkg_when_flag_false_or_omitted(tmp_path: Path, monkeypatch):
+    twin, polygon, mesh_gdf = _fake_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+    output_dir = tmp_path / "OUTPUTS"
+    temp_dir = tmp_path / "TEMP"
+
+    result = operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain", "runoff"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(output_dir),
+        temp_dir=str(temp_dir),
+        area_name="basin_A",
+    )
+
+    gpkgs = list(output_dir.glob("*.gpkg"))
+    assert gpkgs == []
+    assert not any(p.endswith(".gpkg") for p in result.artefacts)
+
+    csv_paths = [p for p in result.artefacts if p.endswith(".csv")]
+    npy_paths = [p for p in result.artefacts if p.endswith(".npy")]
+    assert len(csv_paths) == 2
+    assert len(npy_paths) == 2
+
+
+def test_run_mask_watbal_csv_npy_parity_with_and_without_gpkg(tmp_path: Path, monkeypatch):
+    twin, polygon, mesh_gdf = _fake_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+
+    run_a = tmp_path / "A"
+    run_b = tmp_path / "B"
+    (run_a / "OUTPUTS").mkdir(parents=True)
+    (run_a / "TEMP").mkdir(parents=True)
+    (run_b / "OUTPUTS").mkdir(parents=True)
+    (run_b / "TEMP").mkdir(parents=True)
+
+    operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(run_a / "OUTPUTS"),
+        temp_dir=str(run_a / "TEMP"),
+        area_name="basin_A",
+        write_geopackage=False,
+    )
+
+    operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(run_b / "OUTPUTS"),
+        temp_dir=str(run_b / "TEMP"),
+        area_name="basin_A",
+        write_geopackage=True,
+    )
+
+    files_a = _collect_files(run_a / "OUTPUTS", run_a / "TEMP")
+    files_b = {
+        name: data
+        for name, data in _collect_files(run_b / "OUTPUTS", run_b / "TEMP").items()
+        if not name.endswith(".gpkg")
+    }
+    assert files_a == files_b

--- a/tests/unit/test_operations_mask_watbal_gpkg.py
+++ b/tests/unit/test_operations_mask_watbal_gpkg.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,7 +9,6 @@ from types import SimpleNamespace
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import pytest
 from shapely.geometry import Polygon, box
 
 from HydrologicalTwinAlphaSeries.ht import (
@@ -176,3 +174,201 @@ def test_run_mask_watbal_csv_npy_parity_with_and_without_gpkg(tmp_path: Path, mo
         if not name.endswith(".gpkg")
     }
     assert files_a == files_b
+
+
+# ---------------------------------------------------------------------------
+# weighted=True path
+# ---------------------------------------------------------------------------
+
+
+def _weighted_twin_and_polygon():
+    """Fake twin where mask(kind='area_values', weighted=True) returns
+    populated weights + clipped geometries + cell_ids meta."""
+    cell_ids = [10, 20]
+    cell_geoms = [box(i, 0, i + 1, 1) for i in range(2)]
+    mesh_gdf = gpd.GeoDataFrame(
+        {"id_cell": cell_ids}, geometry=cell_geoms, crs="EPSG:2154"
+    )
+    dates = np.array(["2000-01-01", "2000-01-02", "2000-01-03", "2000-01-04"])
+
+    def fake_mask(kind, **kwargs):
+        if kind == "polygon_cells":
+            return CellSelectionResponse(
+                cell_ids=list(cell_ids),
+                meta={"id_compartment": 1, "kind": "polygon_cells"},
+            )
+        if kind == "area_values":
+            # Weighted=True invariants from the spec:
+            #   - data is volumetric (m³/day)
+            #   - weights and clipped_geometries are populated
+            #   - meta carries cell_ids
+            param = kwargs["param"]
+            base = float(hash(param) % 1000)
+            weights = np.array([1.0, 0.5])
+            # data rows shaped like base * weight (mimicking the dispatcher).
+            data = np.array(
+                [
+                    [base * weights[0]] * len(dates),
+                    [base * weights[1]] * len(dates),
+                ]
+            )
+            return ValuesResponse(
+                data=data,
+                dates=dates,
+                meta={
+                    "cell_ids": list(cell_ids),
+                    "weighted": True,
+                    "target_unit": kwargs.get("target_unit"),
+                },
+                weights=weights,
+                clipped_geometries=cell_geoms,
+            )
+        raise ValueError(f"unexpected mask kind: {kind!r}")
+
+    twin = SimpleNamespace(mask=fake_mask, out_caw_directory="/tmp/fake_out_caw")
+    polygon = Polygon([(0, 0), (3, 0), (3, 1), (0, 1)])
+    return twin, polygon, mesh_gdf
+
+
+def test_run_mask_watbal_weighted_writes_polygon_total_csv(tmp_path: Path, monkeypatch):
+    twin, polygon, mesh_gdf = _weighted_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+    output_dir = tmp_path / "OUTPUTS"
+    temp_dir = tmp_path / "TEMP"
+
+    result = operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(output_dir),
+        temp_dir=str(temp_dir),
+        area_name="basin_A",
+        weighted=True,
+    )
+
+    # polygon_total_paths populated when weighted=True.
+    assert result.polygon_total_paths is not None
+    assert "rain" in result.polygon_total_paths
+    rain_total_path = result.polygon_total_paths["rain"]
+    assert rain_total_path.endswith(
+        "basin_A_rain_polygon_total_2000-2000.csv"
+    )
+    assert Path(rain_total_path).exists()
+
+    # Polygon-total equals the row-sum of the weighted per-cell CSV.
+    total_df = pd.read_csv(rain_total_path, index_col="date")
+    cell_csv = next(p for p in result.artefacts if p.endswith("WATBAL_rain_MB_2000-2000.csv"))
+    cell_df = pd.read_csv(cell_csv, index_col="date")
+    np.testing.assert_allclose(
+        total_df["polygon_total"].values, cell_df.sum(axis=1).values
+    )
+
+
+def test_run_mask_watbal_unweighted_has_no_polygon_total_paths(
+    tmp_path: Path, monkeypatch
+):
+    twin, polygon, mesh_gdf = _weighted_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+    output_dir = tmp_path / "OUTPUTS"
+    temp_dir = tmp_path / "TEMP"
+
+    result = operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(output_dir),
+        temp_dir=str(temp_dir),
+        area_name="basin_A",
+    )
+
+    assert result.polygon_total_paths is None
+    assert not any("polygon_total" in p for p in result.artefacts)
+
+
+def test_run_mask_watbal_weighted_gdf_carries_weight_column(
+    tmp_path: Path, monkeypatch
+):
+    twin, polygon, mesh_gdf = _weighted_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+
+    result = operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(tmp_path / "OUTPUTS"),
+        temp_dir=str(tmp_path / "TEMP"),
+        area_name="basin_A",
+        weighted=True,
+    )
+
+    assert "weight" in result.gdf.columns
+    assert list(result.gdf["cell_id"]) == [10, 20]
+    np.testing.assert_allclose(result.gdf["weight"].values, [1.0, 0.5])
+
+
+def test_run_mask_watbal_unweighted_gdf_has_no_weight_column(
+    tmp_path: Path, monkeypatch
+):
+    twin, polygon, mesh_gdf = _weighted_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+
+    result = operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(tmp_path / "OUTPUTS"),
+        temp_dir=str(tmp_path / "TEMP"),
+        area_name="basin_A",
+    )
+
+    assert "weight" not in result.gdf.columns
+
+
+def test_run_mask_watbal_weighted_gpkg_bundles_weighted_artefacts(
+    tmp_path: Path, monkeypatch
+):
+    twin, polygon, mesh_gdf = _weighted_twin_and_polygon()
+    _patch_twin_helpers(monkeypatch, mesh_gdf)
+    output_dir = tmp_path / "OUTPUTS"
+
+    result = operations.run_mask_watbal(
+        twin,
+        polygon=polygon,
+        polygon_crs="EPSG:2154",
+        params=["rain"],
+        syear=2000,
+        eyear=2000,
+        output_dir=str(output_dir),
+        temp_dir=str(tmp_path / "TEMP"),
+        area_name="basin_A",
+        weighted=True,
+        write_geopackage=True,
+    )
+
+    gpkg_path = output_dir / "basin_A_WATBAL_2000_2000.gpkg"
+    assert gpkg_path.exists()
+    assert str(gpkg_path) in result.artefacts
+
+    with sqlite3.connect(str(gpkg_path)) as con:
+        cells = pd.read_sql_query("SELECT * FROM cells", con)
+        daily = pd.read_sql_query("SELECT * FROM daily_values", con)
+        polygon_total = pd.read_sql_query("SELECT * FROM polygon_total_rain", con)
+        prov = pd.read_sql_query("SELECT * FROM provenance", con)
+
+    assert "weight" in cells.columns
+    # daily_values unit overridden to m3/j on the weighted path.
+    assert set(daily["unit"].unique()) == {"m3/j"}
+    assert sorted(polygon_total.columns) == ["date", "polygon_total"]
+    assert int(prov.iloc[0]["weighted"]) == 1

--- a/tests/unit/test_submodel_export_geopackage.py
+++ b/tests/unit/test_submodel_export_geopackage.py
@@ -77,6 +77,39 @@ def test_save_area_geopackage_writes_three_datasets(tmp_path: Path):
     assert prov_row["htas_ver"] == "000.alpha.test"
 
 
+def test_daily_values_matches_cell_major_reference_expansion(tmp_path: Path):
+    """Guard against a repeat/tile transposition in the vectorised
+    daily_values build (design.md D11): the written table must equal an
+    independent cell-major long-form expansion of the same data."""
+    cells_gdf, values_responses, provenance = _make_fixture(
+        n_cells=4, n_days=3, params=("rain", "runoff")
+    )
+    gpkg_path = str(tmp_path / "basin_test_WATBAL_2000_2000.gpkg")
+
+    save_area_geopackage(gpkg_path, cells_gdf, values_responses, provenance)
+
+    with sqlite3.connect(gpkg_path) as con:
+        daily = pd.read_sql_query("SELECT * FROM daily_values", con)
+
+    # Independent reference: explicit triple loop, cell-major within each param.
+    cell_ids = list(cells_gdf["cell_id"])
+    expected_rows = []
+    for param, response in values_responses.items():
+        data = np.asarray(response.data, dtype=float)
+        dates = list(response.dates)
+        for i, cid in enumerate(cell_ids):
+            for j, date in enumerate(dates):
+                expected_rows.append((cid, date, param, float(data[i, j])))
+    expected = pd.DataFrame(
+        expected_rows, columns=["cell_id", "date", "param", "value"]
+    )
+
+    got = daily[["cell_id", "date", "param", "value"]].reset_index(drop=True)
+    pd.testing.assert_frame_equal(
+        got, expected, check_dtype=False, check_like=False
+    )
+
+
 def test_save_area_geopackage_silently_overwrites_existing_file(tmp_path: Path):
     cells_gdf, values_responses, provenance = _make_fixture()
     gpkg_path = str(tmp_path / "basin_test_WATBAL_2000_2000.gpkg")

--- a/tests/unit/test_submodel_export_geopackage.py
+++ b/tests/unit/test_submodel_export_geopackage.py
@@ -1,0 +1,103 @@
+"""Unit tests for the Tier-1 GeoPackage writer ``save_area_geopackage``."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely.geometry import box
+
+from HydrologicalTwinAlphaSeries.ht import ValuesResponse
+from HydrologicalTwinAlphaSeries.services.private.submodel_export import (
+    save_area_geopackage,
+)
+
+
+def _make_fixture(n_cells: int = 3, n_days: int = 5, params=("rain", "runoff")):
+    geoms = [box(i, 0, i + 1, 1) for i in range(n_cells)]
+    cell_ids = list(range(10, 10 + n_cells))
+    cells_gdf = gpd.GeoDataFrame(
+        {"cell_id": cell_ids},
+        geometry=geoms,
+        crs="EPSG:2154",
+    )
+    dates = np.array([f"2000-01-0{i + 1}" for i in range(n_days)])
+    values_responses = {}
+    for k, param in enumerate(params):
+        data = (np.arange(n_cells * n_days, dtype=float) + k * 100).reshape(
+            n_cells, n_days
+        )
+        values_responses[param] = ValuesResponse(data=data, dates=dates)
+    provenance = {
+        "source_run": "/tmp/out_caw",
+        "syear": 2000,
+        "eyear": 2000,
+        "polygon_crs": "EPSG:2154",
+        "area_name": "basin_test",
+        "polygon_wkt": "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+        "generated_at": "2026-05-28T12:00:00+00:00",
+        "htas_ver": "000.alpha.test",
+        "compartment": "WATBAL",
+        "params": '["rain", "runoff"]',
+    }
+    return cells_gdf, values_responses, provenance
+
+
+def test_save_area_geopackage_writes_three_datasets(tmp_path: Path):
+    cells_gdf, values_responses, provenance = _make_fixture()
+    gpkg_path = str(tmp_path / "basin_test_WATBAL_2000_2000.gpkg")
+
+    save_area_geopackage(gpkg_path, cells_gdf, values_responses, provenance)
+
+    assert Path(gpkg_path).exists()
+
+    cells_back = gpd.read_file(gpkg_path, layer="cells")
+    assert len(cells_back) == 3
+    assert set(cells_back.columns) >= {"cell_id", "geometry"}
+    assert cells_back.crs is not None
+    assert cells_back.crs.to_string() == "EPSG:2154"
+
+    with sqlite3.connect(gpkg_path) as con:
+        daily = pd.read_sql_query("SELECT * FROM daily_values", con)
+        prov = pd.read_sql_query("SELECT * FROM provenance", con)
+
+    assert len(daily) == 3 * 5 * 2
+    assert set(daily.columns) == {"cell_id", "date", "param", "value", "unit"}
+    assert set(daily["param"].unique()) == {"rain", "runoff"}
+    assert (daily["unit"] == "mm/j").all()
+
+    assert len(prov) == 1
+    prov_row = prov.iloc[0].to_dict()
+    assert prov_row["compartment"] == "WATBAL"
+    assert prov_row["area_name"] == "basin_test"
+    assert prov_row["polygon_crs"] == "EPSG:2154"
+    assert prov_row["htas_ver"] == "000.alpha.test"
+
+
+def test_save_area_geopackage_silently_overwrites_existing_file(tmp_path: Path):
+    cells_gdf, values_responses, provenance = _make_fixture()
+    gpkg_path = str(tmp_path / "basin_test_WATBAL_2000_2000.gpkg")
+
+    save_area_geopackage(gpkg_path, cells_gdf, values_responses, provenance)
+
+    cells_gdf2, values_responses2, provenance2 = _make_fixture(
+        n_cells=2, n_days=3, params=("rain",)
+    )
+    provenance2["area_name"] = "basin_other"
+
+    # Second call must not raise and must reflect the new content.
+    save_area_geopackage(gpkg_path, cells_gdf2, values_responses2, provenance2)
+
+    cells_back = gpd.read_file(gpkg_path, layer="cells")
+    assert len(cells_back) == 2
+
+    with sqlite3.connect(gpkg_path) as con:
+        daily = pd.read_sql_query("SELECT * FROM daily_values", con)
+        prov = pd.read_sql_query("SELECT * FROM provenance", con)
+
+    assert len(daily) == 2 * 3 * 1
+    assert set(daily["param"].unique()) == {"rain"}
+    assert prov.iloc[0]["area_name"] == "basin_other"

--- a/tests/unit/tools/test_spatial_utils.py
+++ b/tests/unit/tools/test_spatial_utils.py
@@ -10,6 +10,7 @@ from HydrologicalTwinAlphaSeries.tools.spatial_utils import (
     aq_cells_boundary_faces,
     aq_cells_on_polygon_boundary,
     cells_in_polygon,
+    cells_in_polygon_weighted,
     reaches_inflow_outflow_signs,
     reaches_on_polygon_boundary,
 )
@@ -116,6 +117,160 @@ def test_cells_in_polygon_returns_python_ints_not_numpy():
     # Values from the column come back as numpy ints (from int64 column);
     # what matters is they compare equal to plain ints.
     assert result[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# cells_in_polygon_weighted — area-fraction weighted selection
+# ---------------------------------------------------------------------------
+
+
+def test_cells_in_polygon_weighted_cell_fully_inside_has_weight_one():
+    mesh = _grid_mesh(nx=3, ny=3)
+    polygon = box(0.0, 0.0, 3.0, 3.0)  # covers all 9 cells fully
+
+    result = cells_in_polygon_weighted(mesh, polygon, id_col="cell_id")
+
+    assert len(result) == 9
+    for _, weight, geom in result:
+        assert weight == pytest.approx(1.0)
+        assert not geom.is_empty
+
+
+def test_cells_in_polygon_weighted_cell_fully_outside_excluded():
+    mesh = _grid_mesh(nx=3, ny=3)
+    polygon = box(100.0, 100.0, 200.0, 200.0)
+
+    result = cells_in_polygon_weighted(mesh, polygon, id_col="cell_id")
+
+    assert result == []
+
+
+def test_cells_in_polygon_weighted_partial_overlap_gives_fractional_weight():
+    """Polygon overlapping a single cell by 60% of its area."""
+    mesh = _grid_mesh(nx=2, ny=1)  # cells 0 (x∈[0,1]) and 1 (x∈[1,2])
+    # Cover cell 0 entirely (area 1) and 60% of cell 1 (x∈[1,1.6], full y).
+    polygon = box(0.0, 0.0, 1.6, 1.0)
+
+    result = cells_in_polygon_weighted(mesh, polygon, id_col="cell_id")
+
+    weights = {cell_id: w for cell_id, w, _ in result}
+    assert weights[0] == pytest.approx(1.0)
+    assert weights[1] == pytest.approx(0.6)
+
+
+def test_cells_in_polygon_weighted_keeps_border_cell_with_centroid_outside():
+    """A border cell whose centroid lies *outside* the polygon must still be
+    kept and weighted by its overlap fraction.
+
+    Regression: the prefilter once indexed cell centroids, which silently
+    collapsed the weighted helper back to centroid containment — dropping
+    exactly the partially-overlapping border cells the helper exists to
+    capture. The binary helper (centroid test) still omits the cell; the
+    weighted helper must not.
+    """
+    mesh = _grid_mesh(nx=2, ny=1)  # cell 0: x∈[0,1]; cell 1: x∈[1,2]
+    # Polygon ends at x=1.3: cell 1's centroid (x=1.5) is OUTSIDE, but 30%
+    # of cell 1's area is inside.
+    polygon = box(0.0, 0.0, 1.3, 1.0)
+
+    weighted = cells_in_polygon_weighted(mesh, polygon, id_col="cell_id")
+    weights = {cell_id: w for cell_id, w, _ in weighted}
+
+    assert weights[0] == pytest.approx(1.0)
+    assert weights[1] == pytest.approx(0.3)
+    # The binary (centroid) helper, by contrast, drops the border cell.
+    assert cells_in_polygon(mesh, polygon, id_col="cell_id") == [0]
+
+
+def test_cells_in_polygon_weighted_shared_edge_only_excluded_by_floor():
+    """A polygon that only shares an edge with the cell yields zero area, dropped by 1e-6 floor."""
+    mesh = _grid_mesh(nx=2, ny=1)  # cell 0: x∈[0,1]; cell 1: x∈[1,2]
+    # Sliver polygon touching cell 1 only on its left edge x=1.
+    polygon = box(0.5, 0.0, 1.0, 1.0)
+
+    result = cells_in_polygon_weighted(mesh, polygon, id_col="cell_id")
+
+    # Only cell 0 has true overlap; cell 1 shares only the edge x=1 (area=0).
+    cell_ids = [cid for cid, _, _ in result]
+    assert cell_ids == [0]
+
+
+def test_cells_in_polygon_weighted_multipolygon_sums_across_components():
+    """A cell straddling two MultiPolygon components is counted once with summed fraction."""
+    mesh = _grid_mesh(nx=1, ny=1)  # one cell, x∈[0,1], y∈[0,1]
+    # Two disjoint components, each covering 25% of the cell.
+    multi = MultiPolygon(
+        [
+            box(0.0, 0.0, 0.5, 0.5),  # 0.25 area
+            box(0.5, 0.5, 1.0, 1.0),  # 0.25 area
+        ]
+    )
+
+    result = cells_in_polygon_weighted(mesh, multi, id_col="cell_id")
+
+    assert len(result) == 1
+    _, weight, _ = result[0]
+    assert weight == pytest.approx(0.5)
+
+
+def test_cells_in_polygon_weighted_polygon_with_hole_excludes_inside_hole_cell():
+    """A cell sitting inside a polygon hole has zero intersection area → dropped."""
+    mesh = _grid_mesh(nx=3, ny=3)
+    outer = [(0.0, 0.0), (3.0, 0.0), (3.0, 3.0), (0.0, 3.0), (0.0, 0.0)]
+    hole = [(1.0, 1.0), (2.0, 1.0), (2.0, 2.0), (1.0, 2.0), (1.0, 1.0)]
+    polygon = Polygon(outer, holes=[hole])
+
+    result = cells_in_polygon_weighted(mesh, polygon, id_col="cell_id")
+
+    cell_ids = sorted(cid for cid, _, _ in result)
+    assert 4 not in cell_ids  # centre cell coincides with the hole
+    assert cell_ids == [0, 1, 2, 3, 5, 6, 7, 8]
+
+
+def test_cells_in_polygon_weighted_empty_mesh_returns_empty():
+    mesh = gpd.GeoDataFrame({"cell_id": []}, geometry=[], crs="EPSG:3857")
+    polygon = box(0.0, 0.0, 1.0, 1.0)
+
+    assert cells_in_polygon_weighted(mesh, polygon, id_col="cell_id") == []
+
+
+def test_cells_in_polygon_weighted_clipped_geometry_matches_intersection():
+    """The third tuple element is the actual cell-polygon intersection geometry."""
+    mesh = _grid_mesh(nx=2, ny=1)
+    polygon = box(0.0, 0.0, 1.6, 1.0)
+
+    result = cells_in_polygon_weighted(mesh, polygon, id_col="cell_id")
+
+    geoms = {cid: g for cid, _, g in result}
+    # Cell 0 entirely inside → clip equals the cell.
+    assert geoms[0].area == pytest.approx(1.0)
+    # Cell 1 clipped to x∈[1, 1.6] → area 0.6, bbox right edge at x=1.6.
+    assert geoms[1].area == pytest.approx(0.6)
+    minx, _, maxx, _ = geoms[1].bounds
+    assert maxx == pytest.approx(1.6)
+    assert minx == pytest.approx(1.0)
+
+
+@pytest.mark.slow
+def test_cells_in_polygon_weighted_performance_parity_with_binary():
+    """On a 14k-cell mesh, the weighted helper runs within a small factor of the binary one."""
+    nx, ny = 140, 100
+    mesh = _grid_mesh(nx=nx, ny=ny)
+    half_polygon = box(0.0, 0.0, nx / 2.0, ny)
+
+    start = time.perf_counter()
+    binary = cells_in_polygon(mesh, half_polygon, id_col="cell_id")
+    t_binary = time.perf_counter() - start
+
+    start = time.perf_counter()
+    weighted = cells_in_polygon_weighted(mesh, half_polygon, id_col="cell_id")
+    t_weighted = time.perf_counter() - start
+
+    assert len(weighted) == len(binary)
+    # Both must complete well within the binary's 2s budget; allow a 5x
+    # constant factor for the per-cell intersection cost (computed only on
+    # STRtree survivors).
+    assert t_weighted < 5.0 * max(t_binary, 0.05)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Mask extraction improvements
- Added weighted + intersection functionality to the watbal mask, indexing cell footprints instead of centroids for accurate area-based extraction.
- Enabled exporting the extracted mask as a GeoPackage, integrated directly into the UI.
- Moved mask computation onto a dedicated BackgroundWorker thread to keep the interface responsive and avoid crashes during long extractions.
- Reworked the dialog to guide users through the new options and prevent crashes on GeoPackage export.